### PR TITLE
CHANGED: fixed typo in interface regex 

### DIFF
--- a/webapp/app/js/testif.validators.js
+++ b/webapp/app/js/testif.validators.js
@@ -18,7 +18,7 @@ $(function() {
 });
 $(function() {
     $.validator.addMethod('InterfaceChecker', function(value) {
-        var interface = "^(GigabitEthernet([0-9]+\/[0-9]+)|TenGigabitEthernet([0-9]+\/[0-9]+)|TenGigE([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|Vlan|Bundle-Ether([0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|(?:xe|ge)-([0-9+]\/[0-9]+\/[0-9]+))$";
+        var interface = "^(GigabitEthernet([0-9]+\/[0-9]+)|TenGigabitEthernet([0-9]+\/[0-9]+)|TenGigE([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|Vlan|Bundle-Ether([0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|(?:xe|ge)-([0-9]+\/[0-9]+\/[0-9]+))$";
         return value.match(interface);
     }, "Invalid Interface");
 });


### PR DESCRIPTION
fixed typo in interface regex preventing the webapp from validation junos interface names.
e.g.
* xe-11/0/0 - NOT -- does not match `(?:xe|ge)-([0-9+]\/[0-9]+\/[0-9]+)` -- should have been `(?:xe|ge)-([0-9]+\/[0-9]+\/[0-9]+)`
* xe-+/0/0 - OK
* xe-0/0/1 - OK