### PR TITLE
Hotfix for interface Regex and Clarification about project maintenance with badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
 # kipketer
 A bandwidth testing platform with a strong templating engine
 

--- a/webapp/app/js/testif.validators.js
+++ b/webapp/app/js/testif.validators.js
@@ -18,7 +18,7 @@ $(function() {
 });
 $(function() {
     $.validator.addMethod('InterfaceChecker', function(value) {
-        var interface = "^(GigabitEthernet([0-9]+\/[0-9]+)|TenGigabitEthernet([0-9]+\/[0-9]+)|TenGigE([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|Vlan|Bundle-Ether([0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|(?:xe|ge)-([0-9+]\/[0-9]+\/[0-9]+))$";
+        var interface = "^(GigabitEthernet([0-9]+\/[0-9]+)|TenGigabitEthernet([0-9]+\/[0-9]+)|TenGigE([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|Vlan|Bundle-Ether([0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+)|GigabitEthernet([0-9]+\/[0-9]+\/[0-9]+\/[0-9]+)|(?:xe|ge)-([0-9]+\/[0-9]+\/[0-9]+))$";
         return value.match(interface);
     }, "Invalid Interface");
 });


### PR DESCRIPTION
Hotfix:
- Interface Regex validation does not allow for JUNOS interface names like xe-10/x/y, xe-11/y/z,
- ONLY interfaces xe-[0-9]/x/y would match with the code in it's current state.

Clarification:
- That the project is not currently maintained on regular basis by inserting a badge from http://unmaintained.tech/ in the top of the README.md file.